### PR TITLE
Adding support for setting sensor scales

### DIFF
--- a/Libraries/Arduino/src/MPU9250.cpp
+++ b/Libraries/Arduino/src/MPU9250.cpp
@@ -61,20 +61,20 @@ void MPU9250::getAres() {
   }
 }
 
-void MPU9250::setGScale(uint8_t scale)
+void MPU9250::setGscale(int scale)
 {
   switch(scale)
   {
-    case GFS_250DPS: 
+    case 250: 
           Gscale = GFS_250DPS;
           break;
-    case GFS_500DPS: 
+    case 500: 
           Gscale = GFS_500DPS;
           break;
-    case GFS_1000DPS: 
+    case 1000: 
           Gscale = GFS_1000DPS;
           break;
-    case GFS_2000DPS: 
+    case 2000: 
           Gscale = GFS_2000DPS;
           break;
     default: 
@@ -86,20 +86,20 @@ void MPU9250::setGScale(uint8_t scale)
   writeByte(MPU9250_ADDRESS, GYRO_CONFIG, c ); // Write new GYRO_CONFIG value to register
 }
 
-void MPU9250::setAScale(uint8_t scale)
+void MPU9250::setAscale(int scale)
 {
   switch(scale)
   {
-    case AFS_2G: 
+    case 2: 
           Ascale = AFS_2G;
           break;
-    case AFS_4G: 
+    case 4: 
           Ascale = AFS_4G;
           break;
-    case AFS_8G: 
+    case 8: 
           Ascale = AFS_8G;
           break;
-    case AFS_16G: 
+    case 16: 
           Ascale = AFS_16G;
           break;
     default: 
@@ -111,14 +111,14 @@ void MPU9250::setAScale(uint8_t scale)
   writeByte(MPU9250_ADDRESS, ACCEL_CONFIG, c); // Write new ACCEL_CONFIG register value
 }
 
-void MPU9250::setMScale(uint8_t scale)
+void MPU9250::setMscale(int scale)
 {
   switch(scale)
   {
-    case MFS_14BITS: 
+    case 14: 
           Mscale = MFS_14BITS;
           break;
-    case MFS_16BITS: 
+    case 16: 
           Mscale = MFS_16BITS;
           break;
     default:
@@ -127,7 +127,6 @@ void MPU9250::setMScale(uint8_t scale)
 
   writeByte(AK8963_ADDRESS, AK8963_CNTL, Mscale << 4 | Mmode); // Set new magnetometer data resolution and sample ODR
 }
-
 
 void MPU9250::readAccelData(int16_t * destination)
 {

--- a/Libraries/Arduino/src/MPU9250.cpp
+++ b/Libraries/Arduino/src/MPU9250.cpp
@@ -61,6 +61,73 @@ void MPU9250::getAres() {
   }
 }
 
+void MPU9250::setGScale(uint8_t scale)
+{
+  switch(scale)
+  {
+    case GFS_250DPS: 
+          Gscale = GFS_250DPS;
+          break;
+    case GFS_500DPS: 
+          Gscale = GFS_500DPS;
+          break;
+    case GFS_1000DPS: 
+          Gscale = GFS_1000DPS;
+          break;
+    case GFS_2000DPS: 
+          Gscale = GFS_2000DPS;
+          break;
+    default: 
+          Gscale = GFS_250DPS;
+  }
+
+  uint8_t c = readByte(MPU9250_ADDRESS, GYRO_CONFIG); // get current GYRO_CONFIG register value
+  c = c | Gscale << 3; // Set new scale range for the gyro
+  writeByte(MPU9250_ADDRESS, GYRO_CONFIG, c ); // Write new GYRO_CONFIG value to register
+}
+
+void MPU9250::setAScale(uint8_t scale)
+{
+  switch(scale)
+  {
+    case AFS_2G: 
+          Ascale = AFS_2G;
+          break;
+    case AFS_4G: 
+          Ascale = AFS_4G;
+          break;
+    case AFS_8G: 
+          Ascale = AFS_8G;
+          break;
+    case AFS_16G: 
+          Ascale = AFS_16G;
+          break;
+    default: 
+          Ascale = AFS_2G;
+  }
+
+  uint8_t c = readByte(MPU9250_ADDRESS, ACCEL_CONFIG); // get current ACCEL_CONFIG register value
+  c = c | Ascale << 3; // Set new scale range for the accelerometer 
+  writeByte(MPU9250_ADDRESS, ACCEL_CONFIG, c); // Write new ACCEL_CONFIG register value
+}
+
+void MPU9250::setMScale(uint8_t scale)
+{
+  switch(scale)
+  {
+    case MFS_14BITS: 
+          Mscale = MFS_14BITS;
+          break;
+    case MFS_16BITS: 
+          Mscale = MFS_16BITS;
+          break;
+    default:
+          Mscale = MFS_14BITS;
+  }
+
+  writeByte(AK8963_ADDRESS, AK8963_CNTL, Mscale << 4 | Mmode); // Set new magnetometer data resolution and sample ODR
+}
+
 
 void MPU9250::readAccelData(int16_t * destination)
 {

--- a/Libraries/Arduino/src/MPU9250.h
+++ b/Libraries/Arduino/src/MPU9250.h
@@ -237,6 +237,9 @@ class MPU9250
     void getMres();
     void getGres();
     void getAres();
+    void setGScale(uint8_t scale);
+    void setAScale(uint8_t scale);
+    void setMScale(uint8_t scale);
     void readAccelData(int16_t *);
     void readGyroData(int16_t *);
     void readMagData(int16_t *);

--- a/Libraries/Arduino/src/MPU9250.h
+++ b/Libraries/Arduino/src/MPU9250.h
@@ -237,9 +237,9 @@ class MPU9250
     void getMres();
     void getGres();
     void getAres();
-    void setGScale(uint8_t scale);
-    void setAScale(uint8_t scale);
-    void setMScale(uint8_t scale);
+    void setGscale(int scale);
+    void setAscale(int scale);
+    void setMscale(int scale);
     void readAccelData(int16_t *);
     void readGyroData(int16_t *);
     void readMagData(int16_t *);


### PR DESCRIPTION
In the current implementation, it seems that the only way to change the scale of the sensors is to either directly modify the library or to create a child class of the library class. 

I believe an easier solution to this is to add some simple methods that take the desired scale as arguments and set them as necessary.

These proposed changes ensure only valid scales can be written to each of the three sensors. They also achieve both writing the new scales to the device, and setting the scale value within the library itself.